### PR TITLE
Frameworks / packages / cryptography calls updates; minor fix in SignedLicense constructor

### DIFF
--- a/ThinkSharp.Licensing.Test/CheckSumTest.cs
+++ b/ThinkSharp.Licensing.Test/CheckSumTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ThinkSharp.Licensing.Test

--- a/ThinkSharp.Licensing.Test/EncoderTest.cs
+++ b/ThinkSharp.Licensing.Test/EncoderTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ThinkSharp.Licensing.Test

--- a/ThinkSharp.Licensing.Test/HardwareIdentifierDotNetFullTest.cs
+++ b/ThinkSharp.Licensing.Test/HardwareIdentifierDotNetFullTest.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ThinkSharp.Licensing;
 
 namespace ThinkSharp.Licensing.Test
 {

--- a/ThinkSharp.Licensing.Test/HardwareIdentifierTest.cs
+++ b/ThinkSharp.Licensing.Test/HardwareIdentifierTest.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Jan-Niklas Schäfer. All rights reserved.  
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ThinkSharp.Licensing;
 
 namespace ThinkSharp.Licensing.Test
 {

--- a/ThinkSharp.Licensing.Test/Helper/StringHelperTest.cs
+++ b/ThinkSharp.Licensing.Test/Helper/StringHelperTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ThinkSharp.Licensing.Helper;
 

--- a/ThinkSharp.Licensing.Test/LicTest.cs
+++ b/ThinkSharp.Licensing.Test/LicTest.cs
@@ -33,7 +33,7 @@ namespace ThinkSharp.Licensing.Test
             Assert.AreEqual("ABC", license.HardwareIdentifier);
             Assert.AreEqual("CDE", license.SerialNumber);
             Assert.AreEqual(expireDate, license.ExpirationDate);
-            Assert.AreEqual(DateTime.UtcNow.Date, license.IssueDate);
+            Assert.AreEqual(DateTime.UtcNow.Date, license.IssueDate.Date);
             Assert.AreEqual(2, license.Properties.Count);
             Assert.AreEqual("Value1", license.Properties["Prop1"]);
             Assert.AreEqual("Value2", license.Properties["Prop2"]);
@@ -53,7 +53,7 @@ namespace ThinkSharp.Licensing.Test
             Assert.AreEqual(HardwareIdentifier.NoHardwareIdentifier, license.HardwareIdentifier);
             Assert.AreEqual(SerialNumber.NoSerialNumber, license.SerialNumber);
             Assert.AreEqual(DateTime.MaxValue, license.ExpirationDate);
-            Assert.AreEqual(DateTime.UtcNow.Date, license.IssueDate);
+            Assert.AreEqual(DateTime.UtcNow.Date, license.IssueDate.Date);
             Assert.AreEqual(0, license.Properties.Count);
         }
 

--- a/ThinkSharp.Licensing.Test/LicTest.cs
+++ b/ThinkSharp.Licensing.Test/LicTest.cs
@@ -3,14 +3,11 @@
 
 using System;
 using System.Globalization;
-using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ThinkSharp.Licensing;
-using ThinkSharp.Licensing.Signing.RSA;
 
 namespace ThinkSharp.Licensing.Test
 {
-  [TestClass]
+    [TestClass]
     public class LicTest
     {
         // Private

--- a/ThinkSharp.Licensing.Test/SerialNumberTest.cs
+++ b/ThinkSharp.Licensing.Test/SerialNumberTest.cs
@@ -5,7 +5,6 @@ using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ThinkSharp.Licensing;
 
 namespace ThinkSharp.Licensing.Test
 {

--- a/ThinkSharp.Licensing.Test/SignedLicenseTest.cs
+++ b/ThinkSharp.Licensing.Test/SignedLicenseTest.cs
@@ -4,16 +4,13 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ThinkSharp.Licensing;
-using ThinkSharp.Licensing.Signing.RSA;
 using ThinkSharp.Licensing.Test.Signing;
 
 namespace ThinkSharp.Licensing.Test
 {
-  [TestClass]
+    [TestClass]
     public class SignedLicenseTest
     {
         [TestMethod]

--- a/ThinkSharp.Licensing.Test/SignedLicenseTest.cs
+++ b/ThinkSharp.Licensing.Test/SignedLicenseTest.cs
@@ -156,7 +156,7 @@ namespace ThinkSharp.Licensing.Test
         private static void AssertDefaultPropertiesAreValid(SignedLicense file)
         {
             Assert.AreEqual("HardwareID", file.HardwareIdentifier);
-            Assert.AreEqual(DateTime.UtcNow.Date, file.IssueDate);
+            Assert.AreEqual(DateTime.UtcNow.Date, file.IssueDate.Date);
             Assert.AreEqual("SerialNumber", file.SerialNumber);
         }
 

--- a/ThinkSharp.Licensing.Test/Signing/LengthSigner.cs
+++ b/ThinkSharp.Licensing.Test/Signing/LengthSigner.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Jan-Niklas Schäfer. All rights reserved.  
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
 using ThinkSharp.Licensing.Signing;
 
 namespace ThinkSharp.Licensing.Test.Signing

--- a/ThinkSharp.Licensing.Test/TestHelper.cs
+++ b/ThinkSharp.Licensing.Test/TestHelper.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ThinkSharp.Licensing.Test

--- a/ThinkSharp.Licensing.Test/ThinkSharp.Licensing.Test.csproj
+++ b/ThinkSharp.Licensing.Test/ThinkSharp.Licensing.Test.csproj
@@ -1,15 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net452</TargetFrameworks>
-
+    <TargetFrameworks>net481;netstandard2.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ThinkSharp.Licensing/CheckSumAppender.cs
+++ b/ThinkSharp.Licensing/CheckSumAppender.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
 using System.Text;
 
 namespace ThinkSharp.Licensing

--- a/ThinkSharp.Licensing/Constants.cs
+++ b/ThinkSharp.Licensing/Constants.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Jan-Niklas Schäfer. All rights reserved.  
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
-
 namespace ThinkSharp.Licensing
 {
     internal static class Constants

--- a/ThinkSharp.Licensing/Encoder.cs
+++ b/ThinkSharp.Licensing/Encoder.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
 using System.Text;
 
 namespace ThinkSharp.Licensing

--- a/ThinkSharp.Licensing/HardwareIdentifier.cs
+++ b/ThinkSharp.Licensing/HardwareIdentifier.cs
@@ -27,7 +27,7 @@ namespace ThinkSharp.Licensing
     public static class HardwareIdentifier
     {        
         private static readonly CheckSumAppender CheckSumAppender = new CheckSumAppender(Separator, new CheckSum(4));
-        private static readonly HashAlgorithm MD5 = new MD5CryptoServiceProvider();
+        private static readonly HashAlgorithm MD5Algorithm = MD5.Create();
         private static readonly Encoder Encoder = new Encoder(PartSize);
 
         private const int PartSize = 8;
@@ -36,10 +36,10 @@ namespace ThinkSharp.Licensing
 
         static HardwareIdentifier()
         {
-#if NET5_0
+#if NET6_0_OR_GREATER
             if (OperatingSystem.IsWindows())
 #endif
-                theComputerCharacteristics = new WindowsComputerCharacteristics();
+            theComputerCharacteristics = new WindowsComputerCharacteristics();
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace ThinkSharp.Licensing
             {
 
                 var bytes = Encoding.UTF8.GetBytes(characteristic);
-                bytes = MD5.ComputeHash(bytes);
+                bytes = MD5Algorithm.ComputeHash(bytes);
 
                 encodedCharacteristics.Add(Encoder.Encode(bytes));
             }

--- a/ThinkSharp.Licensing/Helper/StringHelper.cs
+++ b/ThinkSharp.Licensing/Helper/StringHelper.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace ThinkSharp.Licensing.Helper
 {

--- a/ThinkSharp.Licensing/Helper/ValidationHelper.cs
+++ b/ThinkSharp.Licensing/Helper/ValidationHelper.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 
 namespace ThinkSharp.Licensing.Helper
 {

--- a/ThinkSharp.Licensing/Lic.cs
+++ b/ThinkSharp.Licensing/Lic.cs
@@ -2,15 +2,14 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
 using ThinkSharp.Licensing.Signing;
 
 namespace ThinkSharp.Licensing
 {
-  /// <summary>
-  /// Entry point of fluent API for working with licenses.
-  /// </summary>
-  public static class Lic
+    /// <summary>
+    /// Entry point of fluent API for working with licenses.
+    /// </summary>
+    public static class Lic
   {
     /// <summary>
     /// Creates a new builder for creating signed license objects.

--- a/ThinkSharp.Licensing/LicBuilder.cs
+++ b/ThinkSharp.Licensing/LicBuilder.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using ThinkSharp.Licensing.Signing;
 
 namespace ThinkSharp.Licensing

--- a/ThinkSharp.Licensing/LicKeyGenerator.cs
+++ b/ThinkSharp.Licensing/LicKeyGenerator.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Jan-Niklas Schäfer. All rights reserved.  
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
-
 namespace ThinkSharp.Licensing
 {
     internal class LicKeyGenerator : IKeyGenerator

--- a/ThinkSharp.Licensing/Properties/PublishProfiles/HS.pubxml
+++ b/ThinkSharp.Licensing/Properties/PublishProfiles/HS.pubxml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>\\10.0.0.0\shared\dev\packages</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net6.0</TargetFramework>
+    <SelfContained>false</SelfContained>
+  </PropertyGroup>
+</Project>

--- a/ThinkSharp.Licensing/SignedLicense.cs
+++ b/ThinkSharp.Licensing/SignedLicense.cs
@@ -21,7 +21,7 @@ namespace ThinkSharp.Licensing
         // ////////////////////////////////////////////////////////////////////
 
         internal SignedLicense(string hardwareIdentifier, string serialNumber, DateTime issueDate, DateTime expirationDate, IDictionary<string, string> properties)
-            : this(hardwareIdentifier, serialNumber, DateTime.UtcNow.Date, expirationDate, properties, null)
+            : this(hardwareIdentifier, serialNumber, issueDate, expirationDate, properties, null)
         {  }
 
         private SignedLicense(string hardwareIdentifier, string serialNumber, DateTime issueDate, DateTime expirationDate, IDictionary<string, string> properties, string signature)

--- a/ThinkSharp.Licensing/SignedLicense.cs
+++ b/ThinkSharp.Licensing/SignedLicense.cs
@@ -21,8 +21,7 @@ namespace ThinkSharp.Licensing
         // ////////////////////////////////////////////////////////////////////
 
         internal SignedLicense(string hardwareIdentifier, string serialNumber, DateTime issueDate, DateTime expirationDate, IDictionary<string, string> properties)
-            : this(hardwareIdentifier, serialNumber, DateTime.UtcNow.Date, expirationDate, properties, null)
-            // TODO issueDate is not applied here
+            : this(hardwareIdentifier, serialNumber, issueDate, expirationDate, properties, null)
         {  }
 
         private SignedLicense(string hardwareIdentifier, string serialNumber, DateTime issueDate, DateTime expirationDate, IDictionary<string, string> properties, string signature)

--- a/ThinkSharp.Licensing/SignedLicense.cs
+++ b/ThinkSharp.Licensing/SignedLicense.cs
@@ -21,7 +21,8 @@ namespace ThinkSharp.Licensing
         // ////////////////////////////////////////////////////////////////////
 
         internal SignedLicense(string hardwareIdentifier, string serialNumber, DateTime issueDate, DateTime expirationDate, IDictionary<string, string> properties)
-            : this(hardwareIdentifier, serialNumber, issueDate, expirationDate, properties, null)
+            : this(hardwareIdentifier, serialNumber, DateTime.UtcNow.Date, expirationDate, properties, null)
+            // TODO issueDate is not applied here
         {  }
 
         private SignedLicense(string hardwareIdentifier, string serialNumber, DateTime issueDate, DateTime expirationDate, IDictionary<string, string> properties, string signature)

--- a/ThinkSharp.Licensing/SignedLicenseEncryption.cs
+++ b/ThinkSharp.Licensing/SignedLicenseEncryption.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
 using System.Text;
 
 namespace ThinkSharp.Licensing

--- a/ThinkSharp.Licensing/SignedLicenseException.cs
+++ b/ThinkSharp.Licensing/SignedLicenseException.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
 
 namespace ThinkSharp.Licensing
 {

--- a/ThinkSharp.Licensing/Signing/ISigner.cs
+++ b/ThinkSharp.Licensing/Signing/ISigner.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Jan-Niklas Schäfer. All rights reserved.  
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
-
 namespace ThinkSharp.Licensing.Signing
 {
     /// <summary>

--- a/ThinkSharp.Licensing/Signing/RSA/RsaSigner.cs
+++ b/ThinkSharp.Licensing/Signing/RSA/RsaSigner.cs
@@ -16,7 +16,7 @@ namespace ThinkSharp.Licensing.Signing.RSA
         private RsaSigner()
         {
             myCryptoServiceProvider = new RSACryptoServiceProvider();
-            myHashAlgo = new SHA512CryptoServiceProvider();
+            myHashAlgo =  SHA512.Create();
         }
 
         public RsaSigner(RSAParameters rsaParameters)

--- a/ThinkSharp.Licensing/Signing/RSA/RsaSigner.cs
+++ b/ThinkSharp.Licensing/Signing/RSA/RsaSigner.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 

--- a/ThinkSharp.Licensing/Signing/SigningKeyPair.cs
+++ b/ThinkSharp.Licensing/Signing/SigningKeyPair.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Jan-Niklas Schäfer. All rights reserved.  
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
-
 namespace ThinkSharp.Licensing.Signing
 {
     /// <summary>

--- a/ThinkSharp.Licensing/ThinkSharp.Licensing.csproj
+++ b/ThinkSharp.Licensing/ThinkSharp.Licensing.csproj
@@ -10,7 +10,7 @@
     <PackageTags>License Signing Serial Key Security</PackageTags>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
-    <Version>1.0.0</Version>
+    <Version>1.0.0.1</Version>
     <PackageLicenseFile>LICENSE.TXT</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/JanDotNet/ThinkSharp.Licensing</PackageProjectUrl>
     <Copyright>Copyright (c) 2017, 2021 Jan-Niklas Schäfer</Copyright>

--- a/ThinkSharp.Licensing/ThinkSharp.Licensing.csproj
+++ b/ThinkSharp.Licensing/ThinkSharp.Licensing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net481;netstandard2.0;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Jan-Niklas Schäfer</Authors>
     <Company>ThinkSharp</Company>
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Management" Version="5.0.0" />
+    <PackageReference Include="System.Management" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ThinkSharp.Licensing/WindowsComputerCharacteristics.cs
+++ b/ThinkSharp.Licensing/WindowsComputerCharacteristics.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Jan-Niklas Schäfer. All rights reserved.  
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Management;
 using System.Runtime.Versioning;
 using System.Text;

--- a/ThinkSharp.Licensing/WindowsComputerCharacteristics.cs
+++ b/ThinkSharp.Licensing/WindowsComputerCharacteristics.cs
@@ -10,7 +10,7 @@ using System.Text;
 
 namespace ThinkSharp.Licensing
 {
-#if NET5_0
+#if NET6_0_OR_GREATER
     [SupportedOSPlatform("windows")]
 #endif
     internal class WindowsComputerCharacteristics : IComputerCharacteristics


### PR DESCRIPTION
This PR includes:

1. NuGet packages update (testing project);
2. Replaced obsolete constructors 'new MD5CryptoServiceProvider()' and 'new SHA512CryptoServiceProvider()' with 'MD5.Create()' and 'SHA512.Create()' as per Microsoft documentation;
3. Frameworks update (.net5 and net framework 4.6.1 are no longer supported);
4. Updated SignedLicense construtor to properly pass parameter 'issueDate' instead of DateTime.Now;
5. Removed unnecessary using statements.


Note - I didn't update package release notes / version as I don't know how to properly handle this, let me know if I have to make this change before merging.